### PR TITLE
Added pickle support for frames and framevel

### DIFF
--- a/python_orocos_kdl/PyKDL/frames.cpp
+++ b/python_orocos_kdl/PyKDL/frames.cpp
@@ -74,6 +74,21 @@ void init_frames(py::module &m)
             .def_static("Zero", &Vector::Zero)
             .def("Norm", &Vector::Norm)
             .def("Normalize", &Vector::Normalize, py::arg("eps")=epsilon)
+            .def(py::pickle(
+                [](const Vector &v) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    return py::make_tuple(v.x(), v.y(), v.z());
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 3) {
+                        std::cout << "size error\n";
+                        throw std::runtime_error("Invalid state!");
+                    }
+
+                    /* Create a new C++ instance */
+                    Vector v(t[0].cast<double>(), t[1].cast<double>(), t[2].cast<double>());
+                    return v;
+                }))
             ;
     m.def("SetToZero", (void (*)(Vector&)) &KDL::SetToZero);
     m.def("dot", (double (*)(const Vector&, const Vector&)) &KDL::dot);
@@ -153,6 +168,18 @@ void init_frames(py::module &m)
             .def(py::self == py::self)
             .def(py::self != py::self)
             .def(py::self * py::self)
+            .def(py::pickle(
+                [](const Rotation &rot) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    double roll{0}, pitch{0}, yaw{0};
+                    rot.GetRPY(roll, pitch, yaw);
+                    return py::make_tuple(roll, pitch, yaw);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 3) { throw std::runtime_error("Invalid state!"); }
+                    /* Create a new C++ instance */
+                    return Rotation::RPY(t[0].cast<double>(), t[1].cast<double>(), t[2].cast<double>());
+                }))
             ;
     m.def("Equal", (bool (*)(const Rotation&, const Rotation&, double eps)) &KDL::Equal,
           py::arg("a"), py::arg("b"), py::arg("eps")=epsilon);
@@ -207,6 +234,20 @@ void init_frames(py::module &m)
             .def(py::self * py::self)
             .def(py::self == py::self)
             .def(py::self != py::self)
+            .def(py::pickle(
+                [](const Frame &frm) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    return py::make_tuple(frm.M, frm.p);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 2) {
+                        throw std::runtime_error("Invalid state!");
+                    }
+
+                    /* Create a new C++ instance */
+                    Frame frm(t[0].cast<Rotation>(), t[1].cast<Vector>());
+                    return frm;
+                }))
             ;
     m.def("Equal", (bool (*)(const Frame&, const Frame&, double eps)) &KDL::Equal,
           py::arg("a"), py::arg("b"), py::arg("eps")=epsilon);
@@ -252,6 +293,20 @@ void init_frames(py::module &m)
             .def("__neg__", [](const Twist &a) {
                 return operator-(a);
             }, py::is_operator())
+            .def(py::pickle(
+                [](const Twist &tt) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    return py::make_tuple(tt.vel, tt.rot);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 2) {
+                        throw std::runtime_error("Invalid state!");
+                    }
+
+                    /* Create a new C++ instance */
+                    Twist tt(t[0].cast<Vector>(), t[1].cast<Vector>());
+                    return tt;
+                }))
             ;
     m.def("dot", (double (*)(const Twist&, const Wrench&)) &KDL::dot);
     m.def("dot", (double (*)(const Wrench&, const Twist&)) &KDL::dot);
@@ -300,6 +355,20 @@ void init_frames(py::module &m)
             .def("__neg__", [](const Wrench &w) {
                 return operator-(w);
             }, py::is_operator())
+            .def(py::pickle(
+                [](const Wrench &wr) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    return py::make_tuple(wr.force, wr.torque);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 2) {
+                        throw std::runtime_error("Invalid state!");
+                    }
+
+                    /* Create a new C++ instance */
+                    Wrench wr(t[0].cast<Vector>(), t[1].cast<Vector>());
+                    return wr;
+                }))
             ;
     m.def("SetToZero", (void (*)(Wrench&)) &KDL::SetToZero);
     m.def("Equal", (bool (*)(const Wrench&, const Wrench&, double eps)) &KDL::Equal,

--- a/python_orocos_kdl/PyKDL/framevel.cpp
+++ b/python_orocos_kdl/PyKDL/framevel.cpp
@@ -77,6 +77,20 @@ void init_framevel(pybind11::module &m)
             .def("__neg__", [](const VectorVel &a) {
                 return operator-(a);
             }, py::is_operator())
+            .def(py::pickle(
+                [](const VectorVel &vv) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    return py::make_tuple(vv.p, vv.v);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 2) {
+                        throw std::runtime_error("Invalid state!");
+                    }
+
+                    /* Create a new C++ instance */
+                    VectorVel vv(t[0].cast<Vector>(), t[1].cast<Vector>());
+                    return vv;
+                }))
             ;
 
     m.def("Equal", (bool (*)(const VectorVel&, const VectorVel&, double)) &KDL::Equal,
@@ -129,6 +143,20 @@ void init_framevel(pybind11::module &m)
             .def(py::self * py::self)
             .def(Rotation() * py::self)
             .def(py::self * Rotation())
+            .def(py::pickle(
+                [](const RotationVel &rv) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    return py::make_tuple(rv.R, rv.w);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 2) {
+                        throw std::runtime_error("Invalid state!");
+                    }
+
+                    /* Create a new C++ instance */
+                    RotationVel rv(t[0].cast<Rotation>(), t[1].cast<Vector>());
+                    return rv;
+                }))
             ;
     m.def("Equal", (bool (*)(const RotationVel&, const RotationVel&, double)) &KDL::Equal,
           py::arg("r1"), py::arg("r2"), py::arg("eps")=epsilon);
@@ -165,6 +193,20 @@ void init_framevel(pybind11::module &m)
             .def(py::self * py::self)
             .def(Frame() * py::self)
             .def(py::self * Frame())
+            .def(py::pickle(
+                [](const FrameVel &fv) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    return py::make_tuple(fv.M, fv.p);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 2) {
+                        throw std::runtime_error("Invalid state!");
+                    }
+
+                    /* Create a new C++ instance */
+                    FrameVel rv(t[0].cast<RotationVel>(), t[1].cast<VectorVel>());
+                    return rv;
+                }))
             ;
     m.def("Equal", (bool (*)(const FrameVel&, const FrameVel&, double)) &KDL::Equal,
           py::arg("r1"), py::arg("r2"), py::arg("eps")=epsilon);
@@ -206,6 +248,20 @@ void init_framevel(pybind11::module &m)
             .def("__neg__", [](const TwistVel &a) {
                 return operator-(a);
             }, py::is_operator())
+            .def(py::pickle(
+                [](const TwistVel &tv) { // __getstate__
+                    /* Return a tuple that fully encodes the state of the object */
+                    return py::make_tuple(tv.vel, tv.rot);
+                },
+                [](py::tuple t) { // __setstate__
+                    if (t.size() != 2) {
+                        throw std::runtime_error("Invalid state!");
+                    }
+
+                    /* Create a new C++ instance */
+                    TwistVel tv(t[0].cast<VectorVel>(), t[1].cast<VectorVel>());
+                    return tv;
+                }))
             ;
 
     m.def("SetToZero", (void (*)(TwistVel&)) &KDL::SetToZero);

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -160,16 +160,17 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertEqual(F.Inverse()*v,F.Inverse(v))
 
     def testPickle(self):
-        import pickle
+        # import pickle
+        import cPickle as pickle
         data = {}
         data['v'] = Vector(1,2,3)
-        data['rot'] = Rotation.RotX(1.3)
+        data['rot'] = Rotation().EulerZYZ(1, 2, 3)
         data['fr'] = Frame(data['rot'], data['v'])
         data['tw'] = Twist(data['v'], Vector(4,5,6))
         data['wr'] = Wrench(Vector(0.1,0.2,0.3), data['v'])
 
         f = open('/tmp/pickle_test', 'w')
-        pickle.dump(data, f)
+        pickle.dump(data, f, 2)
         f.close()
 
         f = open('/tmp/pickle_test', 'r')

--- a/python_orocos_kdl/tests/frameveltest.py
+++ b/python_orocos_kdl/tests/frameveltest.py
@@ -85,7 +85,7 @@ class FrameVelTestFunctions(unittest.TestCase):
 
     def testPickle(self):
         rot = Rotation.RotX(1.3)
-        import pickle
+        import cPickle as pickle
         data = {}
         data['vv'] = VectorVel(Vector(1,2,3), Vector(4,5,6))
         data['rv'] = RotationVel(rot, Vector(4.1,5.1,6.1))
@@ -93,7 +93,7 @@ class FrameVelTestFunctions(unittest.TestCase):
         data['tv'] = TwistVel(data['vv'], data['vv'])
 
         f = open('/tmp/pickle_test_kdl_framevel', 'w')
-        pickle.dump(data, f)
+        pickle.dump(data, f, 2)
         f.close()
 
         f = open('/tmp/pickle_test_kdl_framevel', 'r')


### PR DESCRIPTION
@MatthijsBurgh Please give this a shot. However, note that this is by no means complete and is not ready to be merged to the main repo. Missing features include Vector2/Rotation2/Frame2 wrapping, pickle support for other classes. Also for Python 2.7 only cPickle and pickle protocol 2 are supported. 
See: https://pybind11.readthedocs.io/en/stable/advanced/classes.html#pickling-support

If you think this pybind11 effort is promising, we can discuss the next steps. Cheers.